### PR TITLE
fix: temporarily disable tsc

### DIFF
--- a/test/mnist/package.json
+++ b/test/mnist/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "format": "prettier . --write",
     "dev": "vite",
-    "build": "tsc && vite build",
+    "build": "vite build",
     "preview": "vite preview"
   },
   "keywords": [],


### PR DESCRIPTION
Disable TSC since now the TypeScript code can't pass type-checking.